### PR TITLE
handling boolean values

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -114,10 +114,19 @@ module.exports = function(mongoose) {
 				val);
 		};
 
+		// boolean values should be handled as booleans, not string values
 		var regexExact = function (val) {
-			return (typeof val === 'string' ?
-				new RegExp('^' + sanitize(val) + '$', 'i') :
-				val);
+			if (typeof val === 'string') {
+				switch(val.toLowerCase()) {
+					case 'false' :
+						return false;
+					case 'true' :
+						return true;
+					default :
+						return new RegExp('^' + sanitize(val) + '$', 'i');
+				}
+			}
+			return val;
 		};
 
 		// MANDATORY


### PR DESCRIPTION
When searching by a boolean value, the internal query became string comparison, which caused unexpected error.  this pull request will ensure when an "exact" filter carries a boolean value, we'll still use a boolean value within the mongoose query.