### PR TITLE
0.2.19 - fixed an issue with isNaN()

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,3 +1,8 @@
+# v0.2.19 / 2016-04-27
+
+* addressed an issue that certain strings were incorrectly parsed as legitimate
+numbers and caused filters with EXACT phrases would fail
+
 # v0.2.18 / 2016-04-13
 
 * Adding support for `exists` mandatory filters

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -23,7 +23,12 @@ module.exports = function(mongoose) {
 					case 'true' : return true;
 					case 'false' : return false;
 					default :
-						if (!isNaN(val)) {
+						// use a regex to validate if val is a real parse-able number
+						// javascript isNaN() treats a string such as '100000329e97' as
+						// a legitimate number, which is not a desirable result
+						// e.g. both Number('100000329e97'), parseInt('100000329e97')
+						// yield a number 100000329, and isNaN('100000329e97') === false
+						if (val.match(/^[-+]?[0-9]*\.?[0-9]+$/) !== null) {
 							// val is a number
 							if (val.indexOf('.') > -1) {
 								// val is a float
@@ -111,7 +116,7 @@ module.exports = function(mongoose) {
 		// like it expects array of objects
 		var applyRegexAsOptional = function (spec, buildRegex) {
 			function bulkApply(key, val) {
-				var 
+				var
 					node = {},
 					nodeOptions = [];
 
@@ -124,7 +129,7 @@ module.exports = function(mongoose) {
 				return nodeOptions;
 			}
 
-			var 
+			var
 				orOptions = [],
 				orOptionsNode = {};
 
@@ -202,7 +207,7 @@ module.exports = function(mongoose) {
 		applyRegex(mandatory.endsWith, regexEndsWith);
 		applyRegex(mandatory.startsWith, regexStartsWith);
 		applyRegex(mandatory.exact, regexExact);
-		
+
 		applyExists(
 			mandatory.exists || {});
 		applyGreaterThan(

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -28,7 +28,7 @@ module.exports = function(mongoose) {
 						// a legitimate number, which is not a desirable result
 						// e.g. both Number('100000329e97'), parseInt('100000329e97')
 						// yield a number 100000329, and isNaN('100000329e97') === false
-						if (val.match(/^[-+]?[0-9]*\.?[0-9]+$/) !== null) {
+						if (/^[-+]?[0-9]*\.?[0-9]+$/.test(val)) {
 							// val is a number
 							if (val.indexOf('.') > -1) {
 								// val is a float

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -34,7 +34,7 @@ module.exports = function(mongoose) {
 								// val is a float
 								return parseFloat(val);
 							} else {
-								return parseInt(val);
+								return parseInt(val, 10);
 							}
 						}
 				}


### PR DESCRIPTION
Previous implementation relies on isNaN() to validate if a string is numeric.  However, it treated a string such as '100000329e97' as a legitimate number and eventually parsed it as 100000329, which caused search error.

Signed-off-by: Stanford Chiang <schiang@playnetwork.com>